### PR TITLE
Update miniAero for Kokkos 3.0 promotion.

### DIFF
--- a/kokkos/Faces.h
+++ b/kokkos/Faces.h
@@ -130,7 +130,7 @@ void copy_faces(Faces<Device> device_faces, std::vector<Face> & mesh_faces){
     typedef Kokkos::BinOp1D< view_type > CompType;
     view_type face_cell_left = Kokkos::subview(device_faces.face_cell_conn_,Kokkos::ALL(),0);
 
-    typedef Kokkos::Experimental::MinMax<int,Device> reducer_type;
+    typedef Kokkos::MinMax<int,Device> reducer_type;
     typedef typename reducer_type::value_type minmax_type;
     minmax_type minmax;
     Kokkos::parallel_reduce(face_cell_left.dimension_0(), KOKKOS_LAMBDA (const int& i, minmax_type& lminmax) {

--- a/kokkos/GreenGauss.h
+++ b/kokkos/GreenGauss.h
@@ -317,7 +317,7 @@ class GreenGauss {
       //Sum of all contributions.
       green_gauss_gradient_sum<Device> gradient_sum(*cells_, gradients);
       Kokkos::parallel_for(mesh_data_->num_owned_cells, gradient_sum);
-      Device().fence();
+      Kokkos::fence();
     }
 
     //communicate the computed gradient for ghost cells.
@@ -325,7 +325,7 @@ class GreenGauss {
       //copy values to be send from device to host
       extract_shared_tensor<Device, 5, 3> extract_shared_gradients(gradients, mesh_data_->send_local_ids, shared_gradient_vars);//sol_np1_vec, send_local_ids, shared_cells);
       Kokkos::parallel_for(mesh_data_->num_ghosts,extract_shared_gradients);
-      Device().fence();
+      Kokkos::fence();
       Kokkos::deep_copy(shared_gradient_vars_host, shared_gradient_vars);
 
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_gradient_vars_host.ptr_on_device(),ghosted_gradient_vars_host.ptr_on_device(), 15);
@@ -334,7 +334,7 @@ class GreenGauss {
       Kokkos::deep_copy(ghosted_gradient_vars, ghosted_gradient_vars_host);
       insert_ghost_tensor<Device, 5, 3> insert_ghost_gradients(gradients, mesh_data_->recv_local_ids, ghosted_gradient_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_gradients);
-      Device().fence();
+      Kokkos::fence();
     }
 
   private:

--- a/kokkos/Makefile
+++ b/kokkos/Makefile
@@ -1,5 +1,6 @@
 KOKKOS_PATH = ${HOME}/kokkos
 KOKKOS_DEVICES = OpenMP
+KOKKOS_OPTIONS = disable_deprecated_code
 
 default: build
 	echo "Start Build"

--- a/kokkos/Makefile
+++ b/kokkos/Makefile
@@ -1,14 +1,14 @@
 KOKKOS_PATH = ${HOME}/kokkos
-KOKKOS_DEVICES=OpenMP
+KOKKOS_DEVICES = OpenMP
 
 default: build
 	echo "Start Build"
 
 ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
-CXX = ${KOKKOS_PATH}/config/nvcc_wrapper
+CXX = ${KOKKOS_PATH}/bin/nvcc_wrapper
 EXE = miniAero.cuda
-KOKKOS_ARCH = "SNB,Kepler35"
-KOKKOS_CUDA_OPTIONS=enable_lambda
+KOKKOS_ARCH = "Maxwell52"
+KOKKOS_CUDA_OPTIONS = enable_lambda
 else
 CXX = g++
 EXE = miniAero.host

--- a/kokkos/Makefile
+++ b/kokkos/Makefile
@@ -1,6 +1,5 @@
 KOKKOS_PATH = ${HOME}/kokkos
 KOKKOS_DEVICES = OpenMP
-KOKKOS_OPTIONS = disable_deprecated_code
 
 default: build
 	echo "Start Build"

--- a/kokkos/StencilLimiter.h
+++ b/kokkos/StencilLimiter.h
@@ -551,11 +551,11 @@ class StencilLimiter{
       Kokkos::parallel_for(nboundary_faces, bc_min_max);
     }
 
-    Device().fence();
+    Kokkos::fence();
 
     gather_min_max<Device> gather(*cells_, stored_min_, stored_max_, stencil_min_, stencil_max_);
     Kokkos::parallel_for(mesh_data_->num_owned_cells, gather);
-    Device().fence();
+    Kokkos::fence();
   }
 
   void communicate_min_max(){
@@ -563,7 +563,7 @@ class StencilLimiter{
   // For min
       extract_shared_vector<Device, 5> extract_shared_min(stencil_min_, mesh_data_->send_local_ids, shared_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, extract_shared_min);
-      Device().fence();
+      Kokkos::fence();
       Kokkos::deep_copy(shared_vars_host, shared_vars);
 
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_vars_host.ptr_on_device(),ghosted_vars_host.ptr_on_device(), 5);
@@ -571,12 +571,12 @@ class StencilLimiter{
       Kokkos::deep_copy(ghosted_vars, ghosted_vars_host);
       insert_ghost_vector<Device, 5> insert_ghost_min(stencil_min_, mesh_data_->recv_local_ids, ghosted_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_min);
-      Device().fence();
+      Kokkos::fence();
 
   // For max
       extract_shared_vector<Device, 5> extract_shared_max(stencil_max_, mesh_data_->send_local_ids, shared_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, extract_shared_max);
-      Device().fence();
+      Kokkos::fence();
       Kokkos::deep_copy(shared_vars_host, shared_vars);
 
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_vars_host.ptr_on_device(),ghosted_vars_host.ptr_on_device(), 5);
@@ -584,7 +584,7 @@ class StencilLimiter{
       Kokkos::deep_copy(ghosted_vars, ghosted_vars_host);
       insert_ghost_vector<Device, 5> insert_ghost_max(stencil_max_, mesh_data_->recv_local_ids, ghosted_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_max);
-      Device().fence();
+      Kokkos::fence();
   // TODO: Maybe combined or overlapped in future.
   }
 
@@ -608,18 +608,18 @@ class StencilLimiter{
       limiter_face<Device, false> limiter_bc(*faces, sol_np1_vec, *cells_, gradients, stencil_min_, stencil_max_, stored_limiter_);
       Kokkos::parallel_for(nboundary_faces, limiter_bc);
     }
-    Device().fence();
+    Kokkos::fence();
 
     gather_limiter<Device> gather(cells_->nfaces_, stored_limiter_, limiter);
     Kokkos::parallel_for(mesh_data_->num_owned_cells, gather);
-    Device().fence();
+    Kokkos::fence();
   }
 
   void communicate_limiter(solution_field_type limiter) {
 
       extract_shared_vector<Device, 5> extract_shared_limiter(limiter, mesh_data_->send_local_ids, shared_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, extract_shared_limiter);
-      Device().fence();
+      Kokkos::fence();
       Kokkos::deep_copy(shared_vars_host, shared_vars);
 
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_vars_host.ptr_on_device(), ghosted_vars_host.ptr_on_device(), 5);
@@ -627,7 +627,7 @@ class StencilLimiter{
       Kokkos::deep_copy(ghosted_vars, ghosted_vars_host);
       insert_ghost_vector<Device, 5> insert_ghost_limiter(limiter, mesh_data_->recv_local_ids, ghosted_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_limiter);
-      Device().fence();
+      Kokkos::fence();
   }
 
   private:

--- a/kokkos/StencilLimiter.h
+++ b/kokkos/StencilLimiter.h
@@ -83,16 +83,16 @@ struct min_max_face{
 KOKKOS_INLINE_FUNCTION
 void operator()( const int& ii )const{
     const int i = permute_vector_(ii);
-    
+
     const int left_index = face_cell_conn_(i,0);
     const int right_index = face_cell_conn_(i,1);
 
     double primitives_l[5];
     double primitives_r[5];
-    
+
     const double gamma = 1.4;
     const double Rgas = 287.05;
-    
+
     if(interior) {
         double r  = cell_values_(left_index, 0);
         double ri = 1.0 / r;
@@ -102,13 +102,13 @@ void operator()( const int& ii )const{
         double k  = 0.5 * (u * u + v * v + w * w);
         double e  = cell_values_(left_index, 4) * ri - k;
         double T  = e * (gamma - 1.0) / Rgas;
-        
+
         primitives_l[0] = r;
         primitives_l[1] = u;
         primitives_l[2] = v;
         primitives_l[3] = w;
         primitives_l[4] = T;
-        
+
         r  = cell_values_(right_index, 0);
         ri = 1.0 / r;
         u  = cell_values_(right_index, 1) * ri;
@@ -117,7 +117,7 @@ void operator()( const int& ii )const{
         k  = 0.5 * (u * u + v * v + w * w);
         e  = cell_values_(right_index, 4) * ri - k;
         T  = e * (gamma - 1.0) / Rgas;
-        
+
         primitives_r[0] = r;
         primitives_r[1] = u;
         primitives_r[2] = v;
@@ -132,7 +132,7 @@ void operator()( const int& ii )const{
         const double k  = 0.5 * (u * u + v * v + w * w);
         const double e  = cell_values_(left_index, 4) * ri - k;
         const double T  = e * (gamma - 1.0) / Rgas;
-        
+
         primitives_l[0] = r;
         primitives_l[1] = u;
         primitives_l[2] = v;
@@ -324,7 +324,7 @@ struct gather_limiter{
   typedef typename ViewTypes<Device>::cell_storage_field_type cell_storage_field_type;
 
   const int nfaces_;
-  cell_storage_field_type stored_limiter_; 
+  cell_storage_field_type stored_limiter_;
   solution_field_type limiter_;
 
   gather_limiter(int nfaces, cell_storage_field_type stored_limiter, solution_field_type limiter):
@@ -369,7 +369,7 @@ struct limiter_face{
   solution_field_type cell_min_, cell_max_, cell_values_;
   vector_field_type face_coordinates_, cell_coordinates_;
   gradient_field_type cell_gradients_;
-  cell_storage_field_type limiter_; 
+  cell_storage_field_type limiter_;
   Kokkos::View<const int*, Device> permute_vector_;
 
   limiter_face(Faces<Device> faces, solution_field_type cell_values, Cells<Device> cells,
@@ -392,7 +392,7 @@ void operator()( const int& ii )const{
   const int i = permute_vector_(ii);
   const int left_index = face_cell_conn_(i,0);
   const int right_index = face_cell_conn_(i,1);
-	
+
   double conservatives_l[5];
 	double conservatives_r[5];
   double primitives_l[5];
@@ -400,7 +400,7 @@ void operator()( const int& ii )const{
 
   for (int icomp = 0; icomp < 5; ++icomp)
   {
-    if(interior){ 
+    if(interior){
       conservatives_l[icomp] = cell_values_(left_index,icomp);
       conservatives_r[icomp] = cell_values_(right_index,icomp);
     }
@@ -410,11 +410,11 @@ void operator()( const int& ii )const{
   }
 
   if(interior){
-    ComputePrimitives<device_type>(conservatives_l, primitives_l); 
-    ComputePrimitives<device_type>(conservatives_r, primitives_r); 
+    ComputePrimitives<device_type>(conservatives_l, primitives_l);
+    ComputePrimitives<device_type>(conservatives_r, primitives_r);
   }
   else{
-    ComputePrimitives<device_type>(conservatives_l, primitives_l); 
+    ComputePrimitives<device_type>(conservatives_l, primitives_l);
   }
 
 //Compute left limiter value and compute right limiter value
@@ -489,10 +489,10 @@ void operator()( const int& ii )const{
 #ifdef CELL_FLUX
 for (int icomp = 0; icomp < 5; ++icomp)
 {
-  limiter_(left_index, cell_flux_index_(i,0), icomp) = limiter_left[icomp]; 
+  limiter_(left_index, cell_flux_index_(i,0), icomp) = limiter_left[icomp];
 
   if(interior){
-    limiter_(right_index, cell_flux_index_(i,1), icomp) = limiter_right[icomp]; 
+    limiter_(right_index, cell_flux_index_(i,1), icomp) = limiter_right[icomp];
   }
 }
 #endif
@@ -538,24 +538,24 @@ class StencilLimiter{
     const int ninternal_faces = internal_faces_->nfaces_;
     min_max_face<Device, true> min_max_internal(*internal_faces_, sol_np1_vec, *cells_, stored_min_, stored_max_);
     Kokkos::parallel_for(ninternal_faces, min_max_internal);
-  
+
     //Boundary Faces
     typename std::vector<Faces<Device> *>::iterator bcf_iter, bcf_iter_end;
     bcf_iter = bc_faces_->begin();
     bcf_iter_end = bc_faces_->end();
-      
+
     for(; bcf_iter != bcf_iter_end; ++bcf_iter){
       Faces<Device> * faces = *bcf_iter;
       const int nboundary_faces = faces->nfaces_;
       min_max_face<Device, false> bc_min_max(*faces, sol_np1_vec, *cells_, stored_min_, stored_max_);
       Kokkos::parallel_for(nboundary_faces, bc_min_max);
     }
-      
-    Device::fence();
-  
+
+    Device().fence();
+
     gather_min_max<Device> gather(*cells_, stored_min_, stored_max_, stencil_min_, stencil_max_);
     Kokkos::parallel_for(mesh_data_->num_owned_cells, gather);
-    Device::fence();
+    Device().fence();
   }
 
   void communicate_min_max(){
@@ -563,28 +563,28 @@ class StencilLimiter{
   // For min
       extract_shared_vector<Device, 5> extract_shared_min(stencil_min_, mesh_data_->send_local_ids, shared_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, extract_shared_min);
-      Device::fence();
+      Device().fence();
       Kokkos::deep_copy(shared_vars_host, shared_vars);
-  
+
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_vars_host.ptr_on_device(),ghosted_vars_host.ptr_on_device(), 5);
-  
+
       Kokkos::deep_copy(ghosted_vars, ghosted_vars_host);
       insert_ghost_vector<Device, 5> insert_ghost_min(stencil_min_, mesh_data_->recv_local_ids, ghosted_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_min);
-      Device::fence();
+      Device().fence();
 
   // For max
       extract_shared_vector<Device, 5> extract_shared_max(stencil_max_, mesh_data_->send_local_ids, shared_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, extract_shared_max);
-      Device::fence();
+      Device().fence();
       Kokkos::deep_copy(shared_vars_host, shared_vars);
-  
+
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_vars_host.ptr_on_device(),ghosted_vars_host.ptr_on_device(), 5);
-  
+
       Kokkos::deep_copy(ghosted_vars, ghosted_vars_host);
       insert_ghost_vector<Device, 5> insert_ghost_max(stencil_max_, mesh_data_->recv_local_ids, ghosted_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_max);
-      Device::fence();
+      Device().fence();
   // TODO: Maybe combined or overlapped in future.
   }
 
@@ -597,7 +597,7 @@ class StencilLimiter{
     limiter_face<Device, true> limiter_internal(*internal_faces_, sol_np1_vec, *cells_, gradients,
       stencil_min_, stencil_max_, stored_limiter_);
     Kokkos::parallel_for(ninternal_faces, limiter_internal);
-  
+
     //Boundary Faces
     typename std::vector<Faces<Device> *>::iterator bcf_iter, bcf_iter_end;
     bcf_iter = bc_faces_->begin();
@@ -608,26 +608,26 @@ class StencilLimiter{
       limiter_face<Device, false> limiter_bc(*faces, sol_np1_vec, *cells_, gradients, stencil_min_, stencil_max_, stored_limiter_);
       Kokkos::parallel_for(nboundary_faces, limiter_bc);
     }
-    Device::fence();
-  
+    Device().fence();
+
     gather_limiter<Device> gather(cells_->nfaces_, stored_limiter_, limiter);
     Kokkos::parallel_for(mesh_data_->num_owned_cells, gather);
-    Device::fence();
+    Device().fence();
   }
 
   void communicate_limiter(solution_field_type limiter) {
 
       extract_shared_vector<Device, 5> extract_shared_limiter(limiter, mesh_data_->send_local_ids, shared_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, extract_shared_limiter);
-      Device::fence();
+      Device().fence();
       Kokkos::deep_copy(shared_vars_host, shared_vars);
-  
+
       communicate_ghosted_cell_data(mesh_data_->sendCount, mesh_data_->recvCount, shared_vars_host.ptr_on_device(), ghosted_vars_host.ptr_on_device(), 5);
-  
+
       Kokkos::deep_copy(ghosted_vars, ghosted_vars_host);
       insert_ghost_vector<Device, 5> insert_ghost_limiter(limiter, mesh_data_->recv_local_ids, ghosted_vars);
       Kokkos::parallel_for(mesh_data_->num_ghosts, insert_ghost_limiter);
-      Device::fence();
+      Device().fence();
   }
 
   private:

--- a/kokkos/TimeSolverExplicitRK4.h
+++ b/kokkos/TimeSolverExplicitRK4.h
@@ -335,7 +335,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
    copy<Device> copy_solution( sol_n_vec, sol_np1_vec);
    Kokkos::parallel_for(nowned_cells, copy_solution);
 
-   Device::fence();
+   Device().fence();
 
    for (ts_data_.time_it = 1; ts_data_.time_it <= ts_data_.max_its; ++ts_data_.time_it)
    {
@@ -354,7 +354,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
         //Update temporary solution used to evaluate the residual for this RK stage
         update<Device> update_rk_stage(alpha_[irk], res_vec, sol_n_vec, sol_temp_vec);
         Kokkos::parallel_for(nowned_cells, update_rk_stage);
-        Device::fence();
+        Device().fence();
 
         #ifdef WITH_MPI
         // Update ghosted values (using sol_temp_vec since it is used for all residual calculations.)
@@ -362,7 +362,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           //copy values to be send from device to host
           extract_shared_vector<Device, 5> extract_shared_values(sol_temp_vec, send_local_ids, shared_conserved_vars);
           Kokkos::parallel_for(num_ghosts,extract_shared_values);
-          Device::fence();
+          Device().fence();
           Kokkos::deep_copy(shared_conserved_vars_host, shared_conserved_vars);
 
           communicate_ghosted_cell_data(sendCount, recvCount, shared_conserved_vars_host.ptr_on_device(),ghosted_conserved_vars_host.ptr_on_device(), 5);
@@ -371,13 +371,13 @@ void TimeSolverExplicitRK4<Device>::Solve()
           Kokkos::deep_copy(ghosted_conserved_vars, ghosted_conserved_vars_host);
           insert_ghost_vector<Device, 5> insert_ghost_values(sol_temp_vec, recv_local_ids, ghosted_conserved_vars);
           Kokkos::parallel_for(num_ghosts, insert_ghost_values);
-          Device::fence();
+          Device().fence();
         #endif
 
         //Zero fluxes
         zero_cell_flux<Device> zero_flux(cells);
         Kokkos::parallel_for(nowned_cells, zero_flux);
-        Device::fence();
+        Device().fence();
 
         //Compute Gradients and Limiters
         if(options_.second_order_space || options_.viscous){
@@ -410,7 +410,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
             compute_face_flux<Device, false, roe_flux<Device>, newtonian_viscous_flux<Device> > fluxop(internal_faces, sol_temp_vec, gradients, limiters, cells, inviscid_flux_evaluator, viscous_flux_evaluator);
             Kokkos::parallel_for(ninternal_faces,fluxop);
           }
-          Device::fence();
+          Device().fence();
         }
         else{
           no_viscous_flux<Device> viscous_flux_evaluator;
@@ -422,7 +422,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
             compute_face_flux<Device, false, roe_flux<Device>, no_viscous_flux<Device> > fluxop(internal_faces, sol_temp_vec, gradients, limiters, cells, inviscid_flux_evaluator, viscous_flux_evaluator);
             Kokkos::parallel_for(ninternal_faces,fluxop);
           }
-          Device::fence();
+          Device().fence();
         }
 
         //Extrapolated BC fluxes
@@ -435,7 +435,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_extrapolateBC_flux<Device, roe_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, inviscid_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device::fence();
+        Device().fence();
 
         //Tangent BC fluxes
         typename std::vector<Faces<Device> >::iterator tf_iter, tf_iter_end;
@@ -447,7 +447,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_tangentBC_flux<Device, roe_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, inviscid_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device::fence();
+        Device().fence();
 
         //Noslip BC fluxes
         typename std::vector<Faces<Device> >::iterator if_iter, if_iter_end;
@@ -460,7 +460,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_NoSlipBC_flux<Device, roe_flux<Device>, newtonian_viscous_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, inviscid_flux_evaluator, viscous_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device::fence();
+        Device().fence();
 
         //Inflow BC fluxes
         typename std::vector<Faces<Device> >::iterator nsf_iter, nsf_iter_end;
@@ -472,17 +472,17 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_inflowBC_flux<Device, roe_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, &inflow_state[0], inviscid_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device::fence();
+        Device().fence();
 
         //Sum up all of the contributions
         apply_cell_flux<Device> flux_residual(cells, res_vec, ts_data_.dt);
         Kokkos::parallel_for(nowned_cells, flux_residual);
-        Device::fence();
- 
+        Device().fence();
+
         //Update np1 solution with each stages contribution
         update<Device> update_fields(beta_[irk],res_vec,sol_np1_vec,sol_np1_vec);
         Kokkos::parallel_for(nowned_cells, update_fields);
-        Device::fence();
+        Device().fence();
       }
       // Update the solution vector after having run all of the RK stages.
       copy<Device> copy_solution( sol_np1_vec, sol_n_vec);
@@ -490,7 +490,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
 
    }
 
-   Device::fence();
+   Device().fence();
    if(my_id_==0){
      fprintf(stdout,"\n ... Device Run time: %8.2f seconds ...\n", timer.seconds());
    }
@@ -505,7 +505,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
    #endif
 
     size_t current_mem_usage, high_water_mem_usage;
-    get_memory_usage(current_mem_usage, high_water_mem_usage); 
+    get_memory_usage(current_mem_usage, high_water_mem_usage);
     current_mem_usage = current_mem_usage/(1024.0*1024.0);
     high_water_mem_usage = high_water_mem_usage/(1024.0*1024.0);
     fprintf(stdout,"\n CPU Memory Usage (Current, High Water) - end of calculation: %lu MB, %lu MB", current_mem_usage, high_water_mem_usage);

--- a/kokkos/TimeSolverExplicitRK4.h
+++ b/kokkos/TimeSolverExplicitRK4.h
@@ -335,7 +335,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
    copy<Device> copy_solution( sol_n_vec, sol_np1_vec);
    Kokkos::parallel_for(nowned_cells, copy_solution);
 
-   Device().fence();
+   Kokkos::fence();
 
    for (ts_data_.time_it = 1; ts_data_.time_it <= ts_data_.max_its; ++ts_data_.time_it)
    {
@@ -354,7 +354,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
         //Update temporary solution used to evaluate the residual for this RK stage
         update<Device> update_rk_stage(alpha_[irk], res_vec, sol_n_vec, sol_temp_vec);
         Kokkos::parallel_for(nowned_cells, update_rk_stage);
-        Device().fence();
+        Kokkos::fence();
 
         #ifdef WITH_MPI
         // Update ghosted values (using sol_temp_vec since it is used for all residual calculations.)
@@ -362,7 +362,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           //copy values to be send from device to host
           extract_shared_vector<Device, 5> extract_shared_values(sol_temp_vec, send_local_ids, shared_conserved_vars);
           Kokkos::parallel_for(num_ghosts,extract_shared_values);
-          Device().fence();
+          Kokkos::fence();
           Kokkos::deep_copy(shared_conserved_vars_host, shared_conserved_vars);
 
           communicate_ghosted_cell_data(sendCount, recvCount, shared_conserved_vars_host.ptr_on_device(),ghosted_conserved_vars_host.ptr_on_device(), 5);
@@ -371,13 +371,13 @@ void TimeSolverExplicitRK4<Device>::Solve()
           Kokkos::deep_copy(ghosted_conserved_vars, ghosted_conserved_vars_host);
           insert_ghost_vector<Device, 5> insert_ghost_values(sol_temp_vec, recv_local_ids, ghosted_conserved_vars);
           Kokkos::parallel_for(num_ghosts, insert_ghost_values);
-          Device().fence();
+          Kokkos::fence();
         #endif
 
         //Zero fluxes
         zero_cell_flux<Device> zero_flux(cells);
         Kokkos::parallel_for(nowned_cells, zero_flux);
-        Device().fence();
+        Kokkos::fence();
 
         //Compute Gradients and Limiters
         if(options_.second_order_space || options_.viscous){
@@ -410,7 +410,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
             compute_face_flux<Device, false, roe_flux<Device>, newtonian_viscous_flux<Device> > fluxop(internal_faces, sol_temp_vec, gradients, limiters, cells, inviscid_flux_evaluator, viscous_flux_evaluator);
             Kokkos::parallel_for(ninternal_faces,fluxop);
           }
-          Device().fence();
+          Kokkos::fence();
         }
         else{
           no_viscous_flux<Device> viscous_flux_evaluator;
@@ -422,7 +422,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
             compute_face_flux<Device, false, roe_flux<Device>, no_viscous_flux<Device> > fluxop(internal_faces, sol_temp_vec, gradients, limiters, cells, inviscid_flux_evaluator, viscous_flux_evaluator);
             Kokkos::parallel_for(ninternal_faces,fluxop);
           }
-          Device().fence();
+          Kokkos::fence();
         }
 
         //Extrapolated BC fluxes
@@ -435,7 +435,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_extrapolateBC_flux<Device, roe_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, inviscid_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device().fence();
+        Kokkos::fence();
 
         //Tangent BC fluxes
         typename std::vector<Faces<Device> >::iterator tf_iter, tf_iter_end;
@@ -447,7 +447,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_tangentBC_flux<Device, roe_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, inviscid_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device().fence();
+        Kokkos::fence();
 
         //Noslip BC fluxes
         typename std::vector<Faces<Device> >::iterator if_iter, if_iter_end;
@@ -460,7 +460,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_NoSlipBC_flux<Device, roe_flux<Device>, newtonian_viscous_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, inviscid_flux_evaluator, viscous_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device().fence();
+        Kokkos::fence();
 
         //Inflow BC fluxes
         typename std::vector<Faces<Device> >::iterator nsf_iter, nsf_iter_end;
@@ -472,17 +472,17 @@ void TimeSolverExplicitRK4<Device>::Solve()
           compute_inflowBC_flux<Device, roe_flux<Device> > boundary_fluxop(bc_faces, sol_temp_vec, cells, &inflow_state[0], inviscid_flux_evaluator);
           Kokkos::parallel_for(nboundary_faces,boundary_fluxop);
         }
-        Device().fence();
+        Kokkos::fence();
 
         //Sum up all of the contributions
         apply_cell_flux<Device> flux_residual(cells, res_vec, ts_data_.dt);
         Kokkos::parallel_for(nowned_cells, flux_residual);
-        Device().fence();
+        Kokkos::fence();
 
         //Update np1 solution with each stages contribution
         update<Device> update_fields(beta_[irk],res_vec,sol_np1_vec,sol_np1_vec);
         Kokkos::parallel_for(nowned_cells, update_fields);
-        Device().fence();
+        Kokkos::fence();
       }
       // Update the solution vector after having run all of the RK stages.
       copy<Device> copy_solution( sol_np1_vec, sol_n_vec);
@@ -490,7 +490,7 @@ void TimeSolverExplicitRK4<Device>::Solve()
 
    }
 
-   Device().fence();
+   Kokkos::fence();
    if(my_id_==0){
      fprintf(stdout,"\n ... Device Run time: %8.2f seconds ...\n", timer.seconds());
    }


### PR DESCRIPTION
These updates were tested on several platforms with OpenMP, Serial, Pthreads, and Cuda backends, with clang version 3.8.1-24 and g++ 6.3.0. Let me know if we want better coverage on compilers/platforms for other miniapp updates.

Now works with deprecated_code enabled or disabled.